### PR TITLE
update conda on every attempt

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -25,7 +25,6 @@ jobs:
     defaults:
       run:
         shell: bash -l {0}
-
     steps:
     - uses: actions/checkout@v4
     - name: initialize conda
@@ -48,11 +47,10 @@ jobs:
     - name: install conda environment
       run:
         mamba env update -n easy -f python_envs/environment.yaml
-      if: steps.conda_cache.outputs.cache-hit != 'true'
       id: install_conda_env
     - name: upload conda environment to cache
       uses: actions/cache/save@v4
-      if: steps.install_conda_env.outcome == 'success'
+      if: (steps.install_conda_env.outcome == 'success')
       with:
         path: ${{ env.CONDA }}/envs
         key:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -33,6 +33,8 @@ jobs:
       env:   
         HASH_BASE: conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('python_envs/environment.yaml', '.github/workflows/run_tests.yaml') }}-${{ env.CONDA_CACHE_NUMBER }}-{{ env.NOW }}
       run: echo "HASH=${HASH_BASE}-${NOW}"  >> $GITHUB_ENV
+    - name: print env
+      run: env
     - name: initialize conda
       uses: conda-incubator/setup-miniconda@v3
       with:
@@ -47,8 +49,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: ${{ env.CONDA }}/envs
-        key:
-          {{ env.HASH }}
+        key:  ${{ env.HASH }}
       id: conda_cache
     - name: install conda environment
       run:
@@ -59,8 +60,7 @@ jobs:
       if: (steps.install_conda_env.outcome == 'success')
       with:
         path: ${{ env.CONDA }}/envs
-        key:
-          ${{ env.HASH }}
+        key: ${{ env.HASH }}
     - name: run tests
       run: |
         conda info

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -31,8 +31,8 @@ jobs:
       run: echo "NOW=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
     - name: compute cache hash
       env:   
-        HASH_BASE: conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('python_envs/environment.yaml', '.github/workflows/run_tests.yaml') }}-${{ env.CONDA_CACHE_NUMBER }}-${{ env.NOW }}
-      run: echo "HASH=${HASH_BASE}-${NOW}"  >> $GITHUB_ENV
+        HASH: conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('python_envs/environment.yaml', '.github/workflows/run_tests.yaml') }}-${{ env.CONDA_CACHE_NUMBER }}-${{ env.NOW }}
+      run: echo "HASH=${HASH}"  >> $GITHUB_ENV
     - name: print env
       run: env
     - name: initialize conda

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -31,7 +31,7 @@ jobs:
       run: echo "NOW=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
     - name: compute cache hash
       env:   
-        HASH_BASE: conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('python_envs/environment.yaml', '.github/workflows/run_tests.yaml') }}-${{ env.CONDA_CACHE_NUMBER }}-{{ env.NOW }}
+        HASH_BASE: conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('python_envs/environment.yaml', '.github/workflows/run_tests.yaml') }}-${{ env.CONDA_CACHE_NUMBER }}-${{ env.NOW }}
       run: echo "HASH=${HASH_BASE}-${NOW}"  >> $GITHUB_ENV
     - name: print env
       run: env

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -33,8 +33,6 @@ jobs:
       env:   
         HASH: conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('python_envs/environment.yaml', '.github/workflows/run_tests.yaml') }}-${{ env.CONDA_CACHE_NUMBER }}-${{ env.NOW }}
       run: echo "HASH=${HASH}"  >> $GITHUB_ENV
-    - name: print env
-      run: env
     - name: initialize conda
       uses: conda-incubator/setup-miniconda@v3
       with:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -27,6 +27,12 @@ jobs:
         shell: bash -l {0}
     steps:
     - uses: actions/checkout@v4
+    - name: Set current date as env variable
+      run: echo "NOW=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+    - name: compute cache hash
+      env:   
+        HASH_BASE: conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('python_envs/environment.yaml', '.github/workflows/run_tests.yaml') }}-${{ env.CONDA_CACHE_NUMBER }}-{{ env.NOW }}
+      run: echo "HASH=${HASH_BASE}-${NOW}"  >> $GITHUB_ENV
     - name: initialize conda
       uses: conda-incubator/setup-miniconda@v3
       with:
@@ -42,7 +48,7 @@ jobs:
       with:
         path: ${{ env.CONDA }}/envs
         key:
-          conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('python_envs/environment.yaml', '.github/workflows/run_tests.yaml') }}-${{ env.CONDA_CACHE_NUMBER }}
+          {{ env.HASH }}
       id: conda_cache
     - name: install conda environment
       run:
@@ -54,7 +60,7 @@ jobs:
       with:
         path: ${{ env.CONDA }}/envs
         key:
-          conda-${{ runner.os }}--${{ runner.arch }}--${{ hashFiles('python_envs/environment.yaml', '.github/workflows/run_tests.yaml') }}-${{ env.CONDA_CACHE_NUMBER }}
+          ${{ env.HASH }}
     - name: run tests
       run: |
         conda info


### PR DESCRIPTION
to see if new packages break things.

Not the most pretty solution, as this only gets uploaded into the cache if there is a difference in the config files, but at the additional downloads are rather minor, and we quickly notice if things break.