### PR TITLE
Make UMLatLon2HealpixRegridder more focused

### DIFF
--- a/dataset_transforms/um_latlon_pp_to_healpix_nc.py
+++ b/dataset_transforms/um_latlon_pp_to_healpix_nc.py
@@ -1,5 +1,5 @@
 """
-Contains a UMHealpixRegridder class that lets you convert from UM lat/lon .pp to .nc
+Contains a UMLatLon2HealpixRegridder class that lets you convert from UM lat/lon .pp to .nc
 Can be run as a command line script with args easy to see in main()
 """
 import sys


### PR DESCRIPTION
Previously, `UMLatLon2HealpixRegridder` tried to handle a lot of aspects of the workflow, from converting Met Office `.pp` format to `.nc`, and handling temporary files etc. I've moved that logic elsewhere so that all this class is more focused: converting a single `xr.DataArray` from lat/lon to healpix, and optionally can coarsen this to all lower-resolution zoom levels. Any input dimensions are handled by constructing an `idx` index that lets you loop over all dimensions that are not lat/lon. (Tested on 2D and 3D data, each with an additional time dimension.)

**Questions:**
1. I am not using `xr.appy_ufunc` to do the remapping - is it worth using? Could this handle any input dimensions? I would have to restructure so that I passed in an `xr.Dataset` instead of an `xr.DataArray` I think.

**Notes**
* The UM lat/lon is in 0-360 longitude - I had to pad the data so that the source domain was larger than the target domain for the Delaunay interpolation (otherwise you get NaNs in the healpix output), and convert healpix lon = 0 to lon = 360.
* There is a separate interpolation method available: `earth2grid`, although this is less tested (and you can't store the weights). Initial testing showed it to be slower by about a factor of 2. 