### PR TITLE
release version locks

### DIFF
--- a/python_envs/environment.yaml
+++ b/python_envs/environment.yaml
@@ -51,7 +51,7 @@ dependencies:
 - uxarray
 - xarray
 - xgcm
-- zarr
+- zarr<3.0.0
 - pip
 - pip:
   - gribscan


### PR DESCRIPTION
Seems to work again. Maybe @wachsylon updated eerie.cloud so it now works with the new xarray?