### PR TITLE
Add the package 'healpy' to environment.yaml

### DIFF
--- a/python_envs/environment.yaml
+++ b/python_envs/environment.yaml
@@ -17,6 +17,7 @@ dependencies:
 - h5netcdf
 - hdf5plugin
 - healpix
+- healpy
 - hvplot
 - intake==0.7.0
 - intake-esm


### PR DESCRIPTION
As the title says, I request to add the [healpy](https://healpy.readthedocs.io/en/latest/index.html) package to the "official" hackathon python environment.
Compared to the `healpix` package, which already is part of the environment, `healpy` offers many more high-level functions, e.g. spherical harmonic transformations or routines to query pixels, that certainly would be useful during the hackathon (and as you could guess would be useful for me ;) ). From a quick discussion with Tobi Kölling I understood that the main reason for using `healpix` instead of `healpy` was the fact that `healpy` does not support Windows. For that reason, we thought of simply adding both packages to the environment. This would still enable Windows users to work with the Healpix data, while at the same time offering the high-level functions to Unix and Mac users.