### PR TITLE
Download script for ECOMIP data

### DIFF
--- a/dataset_transfer/ECOMIP_rclone.md
+++ b/dataset_transfer/ECOMIP_rclone.md
@@ -1,0 +1,94 @@
+# Downloading ECOMIP data from the nowake (Tokyo) http store using rclone
+
+Author: Takashi Arakawa; arakawa@climtech.jp
+
+The Global Hackathon Tokyo node (nowake) offers data access via [http://nowake.nicam.jp/files/](https://nowake.nicam.jp/files/)
+
+*[Rclone](https://rclone.org/) is a command-line program to manage files on cloud storage.*
+
+## Step 1: Configure rclone (one-time setup)
+
+First, create a new configuration for this external S3-compatible storage:
+
+```bash
+rclone --config ./rclone.conf.nicam config
+```
+
+Use the following options:
+
+- **Choose**: `n` to create a new remote.
+- **Enter a name, e.g.**: `nicam`
+- **Choose storage type**: `http`
+- **Endpoint URL**: `https://nowake.nicam.jp/files/`
+- **Edit advanced config?**: `no`
+
+Note: *leave blank* means press the 'return/enter' key without adding anything.
+
+## Step 2: Verify your configuration
+
+Verify your Zarr store path with:
+
+```bash
+rclone --config ./rclone.conf.nicam lsf nicam:ecomip/ms_pres/
+```
+
+## Step 3: Download (sync) the Zarr store locally:
+
+Use sync as it only downloads updated or missing files. So if your download crashes running it again will only transfer files you don't have.
+
+```bash
+rclone --config ./rclone.conf.nicam sync -P nicam:ecomip/ms_pres ./ms_pres --transfers=40 --multi-thread-streams=10 --checkers=100
+```
+
+- `--progress`: Shows real-time progress.
+- `--transfers`: files downloading in parallel.
+- `--checkers`: Number of parallel checks when looking for differences between source and destination.
+- `--multi-thread-streams`: For single large files, this downloads chunks in parallel.
+
+## Extra steps:
+
+You can create a bash script to loop through all available transfers:
+
+```bash
+#!/bin/bash
+set -e  # Exit on any error
+set -u  # Treat unset variables as an error
+
+RCLONE_CONFIG="./rclone.conf.nicam"
+
+# Check if rclone config file exists
+if [ ! -f "$RCLONE_CONFIG" ]; then
+    echo "Error: Rclone config file $RCLONE_CONFIG not found!" >&2
+    exit 1
+fi
+
+REMOTE=nicam
+REMOTE_PATH=ecomip/
+LOCAL_DIR=./ECOMIP_data  # YOU WILL NEED TO ADJUST THIS!
+
+datas=(ms_pres  ms_qg  ms_qr  ms_qv  ms_tem  ms_v  ss_lwu_toa  ss_slp  ss_tbb11um  ss_tppn  ss_v10m ms_qc    ms_qi  ms_qs  ms_rh  ms_u    ms_w  ss_q2m      ss_t2m  ss_tem_sfc  ss_u10m)
+
+dims=(2d 3d)
+freqs=(3h 6h)
+zooms=({0..9})
+
+# Create local output directory
+mkdir -p "${LOCAL_DIR}"
+
+# Generate filenames using combinations of modes and zoom levels
+for data in "${datas[@]}"; do
+            filename="${data}"
+            remote_path="${REMOTE}:${REMOTE_PATH}${filename}/"
+            local_path="${LOCAL_DIR}/${filename}"
+
+            echo "Checking $remote_path..."
+
+            # Check if the remote directory exists (requires accessible structure in HTTP listing)
+            if rclone --config "$RCLONE_CONFIG" lsf "$remote_path" >/dev/null 2>&1; then
+                echo "Syncing $filename ..."
+                rclone --config "$RCLONE_CONFIG" sync "$remote_path" "$local_path" --progress --transfers=40 --multi-thread-streams=10 --checkers=100
+            else
+                echo "Skipping $filename (not found)"
+            fi
+done
+```


### PR DESCRIPTION
This is one example of a short-term NICAM run based on the EarthCARE satellite and the ORCESTRA field campaign (e.g., aircraft and ship observations).  The data are provided on the native grid with a horizontal resolution of 3.5 km and a temporal resolution of 30 minutes for both 2D and 3D variables for a short-term run.