### PR TITLE
Increase the minimum required easygems version

### DIFF
--- a/python_envs/environment_2026.yaml
+++ b/python_envs/environment_2026.yaml
@@ -12,7 +12,7 @@ dependencies:
 - dask
 - dask-jobqueue
 - distributed
-- easygems>=0.1.5
+- easygems>=0.2.0
 - fastparquet
 - flox
 - h5netcdf


### PR DESCRIPTION
`easygems==0.2.0` adds a couple of convenience functions for dataset selection (geospatial extension, [scientific regions](https://regionmask.readthedocs.io/), and sections).

Some brief examples can be found in the bottom half of [this notebook](http://gitlab.dkrz.de/snippets/107). _easygems article will follow soon_