### PR TITLE
Skip libnetcdf 4.10.0

### DIFF
--- a/python_envs/environment_2026.yaml
+++ b/python_envs/environment_2026.yaml
@@ -29,7 +29,7 @@ dependencies:
 - jupyter
 - jupyterlab
 - jupytext
-- libnetcdf>=4.9.2
+- libnetcdf>=4.9.2,!=4.10.0
 - matplotlib
 - netcdf4
 - numba


### PR DESCRIPTION
Using this version of the NetCDF library leads to problem when reading files using Zstd compression filter.

Maybe we should also add a test for this? 